### PR TITLE
Fix readme etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,15 @@
 # Custom swift & Xcode gitignore
-# Cache & build files
+## Cache & build files
 DerivedData/
 /.build
 build/
+.swiftpm/
+.vscode
 
-# Generated file
+## Generated file
 R.generated.swift
 
-# Firebase analytics config file
+## Firebase analytics config file
 GoogleService-Info.plist
 
 

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,131 @@
-# XProjGen
+# XprojGen
+
+XprojGenは、iOSアプリケーション用のXcodeプロジェクトを自動生成するSwift製のコマンドラインツールです。
+[XcodeGen](https://github.com/yonaskolb/XcodeGen)と[Stencil](https://github.com/stencilproject/Stencil)を使用して、SwiftUIベースのプロジェクトを瞬時に作成できます。
+また、`R.swift`や`SwiftLint`も自動的にプロジェクトに組み込まれます。
+
+## 使用方法
+
+### 基本的な使用方法
+
+```bash
+mint run akidon0000/XprojGen xprojgen [プロダクト名]
+```
+
+これにより、以下の構造でプロジェクトが生成されます：
+
+```
+MyApp/
+├── MyApp.xcodeproj
+├── MyApp/
+│   ├── MyAppApp.swift
+│   └── ContentView.swift
+```
+
+### フラット構造での生成
+
+```bash
+xprojgen MyApp --flat
+# または
+xprojgen MyApp -f
+```
+
+フラット構造では、現在のディレクトリに直接プロジェクトファイルが生成されます：
+
+```
+./
+├── MyApp.xcodeproj
+├── MyApp/
+│   ├── MyAppApp.swift
+│   └── ContentView.swift
+```
+
+### オプション
+
+- `--flat`, `-f`: フラットなディレクトリ構造で生成します
+- `--help`, `-h`: ヘルプメッセージを表示します
+
+## 生成されるファイル
+
+### App.swift
+メインのアプリケーションエントリーポイント：
+
+```swift
+@main
+struct MyAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+### ContentView.swift
+SwiftUIベースのメインビュー：
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world! MyApp")
+        }
+        .padding()
+    }
+}
+```
+
+### プロジェクト設定
+- **プラットフォーム**: iOS
+- **Swift バージョン**: 6.0
+- **Bundle Identifier**: `com.github.akidon0000.makexproj.gen.[プロダクト名]`
+- **Info.plist**: 自動生成
+- **ビルド設定**: Debug/Release設定を含む
+
+## 開発
+
+## インストール
+
+### クローンしてビルド
+
+```bash
+git clone https://github.com/akidon0000/XprojGen.git
+cd XprojGen
+swift build -c release
+```
+
+実行可能ファイルは `.build/release/xprojgen` に作成されます。
+
+### パッケージとして実行
+
+```bash
+swift run --package-path /path/to/XprojGen xprojgen [プロダクト名]
+```
+
+### ビルド
+
+```bash
+swift build
+```
+
+### 依存関係
+
+- [apple/swift-argument-parser](https://github.com/apple/swift-argument-parser): コマンドライン引数の解析
+- [stencilproject/Stencil](https://github.com/stencilproject/Stencil): テンプレートエンジン
+- [yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen): Xcodeプロジェクト生成
+
+## ライセンス
+
+このプロジェクトは[LICENSE](LICENSE)ファイルに記載されたライセンスの下で公開されています。
+
+## 参考リンク
+
+- [mtj0928/SlideGen](https://github.com/mtj0928/SlideGen)
+  本プロジェクトのインスピレーション元となったツールです。
+
+## 作者
+
+[akidon0000](https://x.com/akidon0000)


### PR DESCRIPTION
このプルリクエストには 2 つの変更が含まれています：
1つ目は ワークスペースデータファイルの削除、
2つ目は XprojGen プロジェクト向けの詳細な README の追加 です。
README では、このツールの機能、使用方法、依存関係に関する包括的な情報が提供されています。

📚 ドキュメントの更新:
[README.md](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R131):
XprojGen の目的、使い方、プロジェクト構成、生成ファイル、開発環境のセットアップ、インストール手順、依存関係、ライセンス、参考リンクなど、詳細な説明を追加しました。
これにより、プロジェクトのドキュメントが大幅に強化されました。

🧹 ワークスペースの整理:
[.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata](diffhunk://#diff-129f08f050d3ef79c2f2e16623a5b2d43c9c653ef2f06f42eddb7bdef1af6a08L1-L7):
使用されていないワークスペースデータファイルを削除しました。これは不要ファイルの整理の一環と思われます。